### PR TITLE
Update App.jsx

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -182,7 +182,7 @@ const App = () => {
             >
               <TileLayer
                 attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-                url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
               />
               <Marker
                 


### PR DESCRIPTION
`{s}.` is no longer recommended now that we support HTTP/2 + HTTP/3.